### PR TITLE
Floor Repairs

### DIFF
--- a/src/model/actions/crafting-action.ts
+++ b/src/model/actions/crafting-action.ts
@@ -144,22 +144,22 @@ export abstract class CraftingAction {
   public getBaseProgression(simulation: Simulation): number {
     // Progress = (Craftsmanship + 10000) / (SuggestedCraftsmanship + 10000) * ((Craftsmanship * 21) / 100 + 2) * CraftLevelDifference.Progress / 100
     const stats = simulation.crafterStats;
-    return Math.floor(
+    return (
       (((stats.craftsmanship + 10000) / (simulation.recipe.suggestedCraftsmanship + 10000)) *
         ((stats.craftsmanship * 21) / 100 + 2) *
         this.getLevelDifference(simulation).ProgressFactor) /
-        100
+      100
     );
   }
 
   public getBaseQuality(simulation: Simulation): number {
     // Quality = (Control + 10000) / (SuggestedControl + 10000) * ((Control * 35) / 100 + 35) * CraftLevelDifference.Quality / 100
     const stats = simulation.crafterStats;
-    return Math.floor(
+    return (
       (((stats.getControl(simulation) + 10000) / (simulation.recipe.suggestedControl + 10000)) *
         ((stats.getControl(simulation) * 35) / 100 + 35) *
         this.getLevelDifference(simulation).QualityFactor) /
-        100
+      100
     );
   }
 }

--- a/src/model/actions/other/delicate-synthesis.ts
+++ b/src/model/actions/other/delicate-synthesis.ts
@@ -25,7 +25,7 @@ export class DelicateSynthesis extends GeneralAction {
       progressBonus += 0.2;
     }
     simulation.progression += Math.floor(
-      (this.getBaseProgression(simulation) * progressPotency * progressBonus) / 100
+      (Math.floor(this.getBaseProgression(simulation)) * progressPotency * progressBonus) / 100
     );
     if (simulation.hasBuff(Buff.FINAL_APPRAISAL)) {
       simulation.progression = Math.min(simulation.progression, simulation.recipe.progress - 1);
@@ -40,9 +40,7 @@ export class DelicateSynthesis extends GeneralAction {
     if (simulation.hasBuff(Buff.INNOVATION)) {
       qualityBonus += 0.2;
     }
-    let qualityIncrease = Math.floor(
-      (this.getBaseQuality(simulation) * qualityPotency * qualityBonus) / 100
-    );
+    let qualityIncrease = this.getBaseQuality(simulation);
     switch (simulation.state) {
       case 'EXCELLENT':
         qualityIncrease *= 4;
@@ -56,7 +54,9 @@ export class DelicateSynthesis extends GeneralAction {
       default:
         break;
     }
-    simulation.quality += Math.floor(qualityIncrease);
+    simulation.quality += Math.floor(
+      (Math.floor(qualityIncrease) * qualityPotency * qualityBonus) / 100
+    );
     if (simulation.hasBuff(Buff.INNER_QUIET) && simulation.getBuff(Buff.INNER_QUIET).stacks < 11) {
       simulation.getBuff(Buff.INNER_QUIET).stacks++;
     }

--- a/src/model/actions/progress-action.ts
+++ b/src/model/actions/progress-action.ts
@@ -18,7 +18,7 @@ export abstract class ProgressAction extends GeneralAction {
     if (simulation.hasBuff(Buff.INNOVATION)) {
       bonus += 0.2;
     }
-    const addition = (this.getBaseProgression(simulation) * potency * bonus) / 100;
+    const addition = (Math.floor(this.getBaseProgression(simulation)) * potency * bonus) / 100;
     simulation.progression += Math.floor(addition);
     if (simulation.hasBuff(Buff.FINAL_APPRAISAL)) {
       simulation.progression = Math.min(simulation.progression, simulation.recipe.progress - 1);

--- a/src/model/actions/quality-action.ts
+++ b/src/model/actions/quality-action.ts
@@ -9,16 +9,10 @@ export abstract class QualityAction extends GeneralAction {
   }
 
   execute(simulation: Simulation, safe = false, skipStackAddition = false): void {
-    let potency = this.getPotency(simulation);
     let bonus = 1;
-    if (simulation.hasBuff(Buff.GREAT_STRIDES)) {
-      bonus += 1;
-      simulation.removeBuff(Buff.GREAT_STRIDES);
-    }
-    if (simulation.hasBuff(Buff.INNOVATION)) {
-      bonus += 0.2;
-    }
-    let qualityIncrease = (this.getBaseQuality(simulation) * potency * bonus) / 100;
+    let potency = this.getPotency(simulation);
+    let qualityIncrease = this.getBaseQuality(simulation);
+
     switch (simulation.state) {
       case 'EXCELLENT':
         qualityIncrease *= 4;
@@ -32,7 +26,17 @@ export abstract class QualityAction extends GeneralAction {
       default:
         break;
     }
-    simulation.quality += Math.floor(qualityIncrease);
+
+    if (simulation.hasBuff(Buff.GREAT_STRIDES)) {
+      bonus += 1;
+      simulation.removeBuff(Buff.GREAT_STRIDES);
+    }
+    if (simulation.hasBuff(Buff.INNOVATION)) {
+      bonus += 0.2;
+    }
+
+    simulation.quality += Math.floor((Math.floor(qualityIncrease) * potency * bonus) / 100);
+
     if (
       simulation.hasBuff(Buff.INNER_QUIET) &&
       simulation.getBuff(Buff.INNER_QUIET).stacks < 11 &&

--- a/src/model/tables.ts
+++ b/src/model/tables.ts
@@ -103,20 +103,6 @@ export class Tables {
     100
   ];
 
-  public static readonly NYMEIAS_WHEEL_TABLE: { [index: number]: number } = {
-    1: 30,
-    2: 30,
-    3: 30,
-    4: 20,
-    5: 20,
-    6: 20,
-    7: 10,
-    8: 10,
-    9: 10,
-    10: 10,
-    11: 10
-  };
-
   public static readonly LEVEL_TABLE: { [index: number]: number } = {
     51: 120, // 120
     52: 125, // 125

--- a/test/ingenuity.spec.ts
+++ b/test/ingenuity.spec.ts
@@ -55,14 +55,16 @@ describe('Ingenuity', () => {
       try {
         simulation.run(true);
 
-        expect(new TestAction().getBaseProgression(simulation)).toBe(entry.progress100);
-        expect(new TestAction().getBaseQuality(simulation)).toBe(entry.quality100);
+        expect(Math.floor(new TestAction().getBaseProgression(simulation))).toBe(entry.progress100);
+        expect(Math.floor(new TestAction().getBaseQuality(simulation))).toBe(entry.quality100);
 
         simulation.actions.push(new Ingenuity());
         simulation.run(true);
 
-        expect(new TestAction().getBaseProgression(simulation)).toBe(entry.progress100Ingen);
-        expect(new TestAction().getBaseQuality(simulation)).toBe(entry.quality100Ingen);
+        expect(Math.floor(new TestAction().getBaseProgression(simulation))).toBe(
+          entry.progress100Ingen
+        );
+        expect(Math.floor(new TestAction().getBaseQuality(simulation))).toBe(entry.quality100Ingen);
       } catch (e) {
         console.log(entry);
         console.log(new TestAction().getLevelDifference(simulation));


### PR DESCRIPTION
This likely needs a bunch of double checking and testing because I'm not sure I got all those `/100`'s correct.

The formula should be returning a non-floored base effect, which multiplies by condition *before* flooring. This should be the formula itself, stats adjustment, level adjustment, and condition modifier. This is floored and then buffs and efficiency are applied before a final flooring, for a total of 2 floors (rather than the old 3).

I'm not sure if the baseQuality/baseProgress methods get weird with return types on a float vs integer, but the math here should be correct now. The bug mostly causes a 1-3 discrepancy in progress or quality and is most easily seen under Ingenuity.