### PR TITLE
Fix Patient Touch IQ adjustment on action failure

### DIFF
--- a/src/model/actions/quality/patient-touch.ts
+++ b/src/model/actions/quality/patient-touch.ts
@@ -10,6 +10,9 @@ export class PatientTouch extends QualityAction {
 
   execute(simulation: Simulation): void {
     super.execute(simulation);
+
+    // We have to decrement stacks by 1 because the super exec increments
+    // from successful Patient before getting to this part.
     if (simulation.hasBuff(Buff.INNER_QUIET) && simulation.getBuff(Buff.INNER_QUIET).stacks < 11) {
       const iq = simulation.getBuff(Buff.INNER_QUIET);
       iq.stacks = Math.min((iq.stacks - 1) * 2, 11);
@@ -18,7 +21,7 @@ export class PatientTouch extends QualityAction {
 
   onFail(simulation: Simulation): void {
     if (simulation.getBuff(Buff.INNER_QUIET)) {
-      simulation.getBuff(Buff.INNER_QUIET).stacks = Math.floor(
+      simulation.getBuff(Buff.INNER_QUIET).stacks = Math.ceil(
         simulation.getBuff(Buff.INNER_QUIET).stacks / 2
       );
     }


### PR DESCRIPTION
Patient Touch should be flooring towards zero as it's a negative addition, much like how Sturdy works on Prudent. Fixing as per the report in Discord from powerful troubleshooter Lisa Hunt:

> **The simulator doesn't properly round patient touch IQ stacks on failure**
> **Version:** 7.0.15
> **Steps to reproduce:** Open the simulator and simulate the craft until you have an uneven amount of IQ stacks, then place in a patient touch and set it to fail.
> **Shown behavior:** The IQ stacks are halved then rounded down (eg. 5 -> 2 | 7 -> 3 | 9 -> 4 ect...)
> **Expected behaviour:** The IQ stacks are halved then rounded up (eg. 5 -> 3 | 7 -> 4 | 9 -> 5 ect...)
> **Supporting screenshots:**
> Simulator rounding down https://i.imgur.com/2B5UTcD.png
> In-game rounding up - steps https://i.imgur.com/kgrb7Ya.png
> In-game rounding up - result https://i.imgur.com/V4miWQU.png