### PR TITLE
Malleable Flooring

### DIFF
--- a/src/model/actions/general-action.ts
+++ b/src/model/actions/general-action.ts
@@ -26,6 +26,10 @@ export abstract class GeneralAction extends CraftingAction {
     return 1;
   }
 
+  getBaseCondition(simulation: Simulation): number {
+    return 1;
+  }
+
   abstract getPotency(simulation: Simulation): number;
 
   abstract getBaseDurabilityCost(simulationState: Simulation): number;

--- a/src/model/actions/other/delicate-synthesis.ts
+++ b/src/model/actions/other/delicate-synthesis.ts
@@ -37,8 +37,10 @@ export class DelicateSynthesis extends GeneralAction {
       progressBuffMod += 0.5;
     }
 
+    const progressEfficiency = progressPotency * progressBuffMod / 100
+
     simulation.progression += Math.floor(
-      (Math.floor(progressionIncrease) * progressConditionMod * progressPotency * progressBuffMod) / 100
+      Math.floor(progressionIncrease) * progressConditionMod * progressEfficiency
     );
 
     if (
@@ -77,9 +79,12 @@ export class DelicateSynthesis extends GeneralAction {
       qualityBuffMod += 0.5;
     }
 
+    const qualityEfficiency = qualityPotency * qualityBuffMod / 100
+
     simulation.quality += Math.floor(
-      (Math.floor(qualityIncrease * qualityConditionMod) * qualityPotency * qualityBuffMod) / 100
+      Math.floor(qualityIncrease * qualityConditionMod) * qualityEfficiency
     );
+
     if (simulation.hasBuff(Buff.INNER_QUIET) && simulation.getBuff(Buff.INNER_QUIET).stacks < 11) {
       simulation.getBuff(Buff.INNER_QUIET).stacks++;
     }

--- a/src/model/actions/other/delicate-synthesis.ts
+++ b/src/model/actions/other/delicate-synthesis.ts
@@ -16,26 +16,31 @@ export class DelicateSynthesis extends GeneralAction {
 
   execute(simulation: Simulation): void {
     // Progress
+    const progressionIncrease = this.getBaseProgression(simulation);
     const progressPotency = this.getPotency(simulation);
-    let progressBonus = 1;
-    if (simulation.hasBuff(Buff.MUSCLE_MEMORY)) {
-      progressBonus += 1;
-      simulation.removeBuff(Buff.MUSCLE_MEMORY);
-    }
-    if (simulation.hasBuff(Buff.VENERATION)) {
-      progressBonus += 0.5;
-    }
-    let progressionIncrease = this.getBaseProgression(simulation);
+    let progressBuffMod = this.getBaseBonus(simulation);
+    let progressConditionMod = this.getBaseCondition(simulation);
+
     switch (simulation.state) {
       case StepState.MALLEABLE:
-        progressionIncrease *= 1.5;
+        progressConditionMod *= 1.5;
         break;
       default:
         break;
     }
+
+    if (simulation.hasBuff(Buff.MUSCLE_MEMORY)) {
+      progressBuffMod += 1;
+      simulation.removeBuff(Buff.MUSCLE_MEMORY);
+    }
+    if (simulation.hasBuff(Buff.VENERATION)) {
+      progressBuffMod += 0.5;
+    }
+
     simulation.progression += Math.floor(
-      (Math.floor(progressionIncrease) * progressPotency * progressBonus) / 100
+      (Math.floor(progressionIncrease) * progressConditionMod * progressPotency * progressBuffMod) / 100
     );
+
     if (
       simulation.hasBuff(Buff.FINAL_APPRAISAL) &&
       simulation.progression >= simulation.recipe.progress
@@ -43,32 +48,37 @@ export class DelicateSynthesis extends GeneralAction {
       simulation.progression = Math.min(simulation.progression, simulation.recipe.progress - 1);
       simulation.removeBuff(Buff.FINAL_APPRAISAL);
     }
+
     // Quality
+    const qualityIncrease = this.getBaseQuality(simulation);
     const qualityPotency = this.getPotency(simulation);
-    let qualityBonus = 1;
-    if (simulation.hasBuff(Buff.GREAT_STRIDES)) {
-      qualityBonus += 1;
-      simulation.removeBuff(Buff.GREAT_STRIDES);
-    }
-    if (simulation.hasBuff(Buff.INNOVATION)) {
-      qualityBonus += 0.5;
-    }
-    let qualityIncrease = this.getBaseQuality(simulation);
+    let qualityBuffMod = this.getBaseBonus(simulation);
+    let qualityConditionMod = this.getBaseCondition(simulation);
+
     switch (simulation.state) {
       case StepState.EXCELLENT:
-        qualityIncrease *= 4;
+        qualityConditionMod *= 4;
         break;
       case StepState.POOR:
-        qualityIncrease *= 0.5;
+        qualityConditionMod *= 0.5;
         break;
       case StepState.GOOD:
-        qualityIncrease *= 1.5;
+        qualityConditionMod *= 1.5;
         break;
       default:
         break;
     }
+
+    if (simulation.hasBuff(Buff.GREAT_STRIDES)) {
+      qualityBuffMod += 1;
+      simulation.removeBuff(Buff.GREAT_STRIDES);
+    }
+    if (simulation.hasBuff(Buff.INNOVATION)) {
+      qualityBuffMod += 0.5;
+    }
+
     simulation.quality += Math.floor(
-      (Math.floor(qualityIncrease) * qualityPotency * qualityBonus) / 100
+      (Math.floor(qualityIncrease * qualityConditionMod) * qualityPotency * qualityBuffMod) / 100
     );
     if (simulation.hasBuff(Buff.INNER_QUIET) && simulation.getBuff(Buff.INNER_QUIET).stacks < 11) {
       simulation.getBuff(Buff.INNER_QUIET).stacks++;

--- a/src/model/actions/progress-action.ts
+++ b/src/model/actions/progress-action.ts
@@ -12,7 +12,7 @@ export abstract class ProgressAction extends GeneralAction {
   execute(simulation: Simulation): void {
     let buffMod = this.getBaseBonus(simulation);
     let conditionMod = this.getBaseCondition(simulation);
-    let potency = this.getPotency(simulation);
+    const potency = this.getPotency(simulation);
     const progressionIncrease = this.getBaseProgression(simulation);
 
     switch (simulation.state) {
@@ -31,7 +31,11 @@ export abstract class ProgressAction extends GeneralAction {
       buffMod += 0.5;
     }
 
-    simulation.progression += Math.floor((Math.floor(progressionIncrease) * conditionMod * potency * buffMod) / 100);
+    const efficiency = potency * buffMod / 100
+
+    simulation.progression += Math.floor(
+      Math.floor(progressionIncrease) * conditionMod * efficiency
+    );
 
     if (
       simulation.hasBuff(Buff.FINAL_APPRAISAL) &&

--- a/src/model/actions/progress-action.ts
+++ b/src/model/actions/progress-action.ts
@@ -10,27 +10,28 @@ export abstract class ProgressAction extends GeneralAction {
   }
 
   execute(simulation: Simulation): void {
-    let bonus = this.getBaseBonus(simulation);
+    let buffMod = this.getBaseBonus(simulation);
+    let conditionMod = this.getBaseCondition(simulation);
     let potency = this.getPotency(simulation);
-    let progressionIncrease = this.getBaseProgression(simulation);
+    const progressionIncrease = this.getBaseProgression(simulation);
 
     switch (simulation.state) {
       case StepState.MALLEABLE:
-        progressionIncrease *= 1.5;
+        conditionMod *= 1.5;
         break;
       default:
         break;
     }
 
     if (simulation.hasBuff(Buff.MUSCLE_MEMORY)) {
-      bonus += 1;
+      buffMod += 1;
       simulation.removeBuff(Buff.MUSCLE_MEMORY);
     }
     if (simulation.hasBuff(Buff.VENERATION)) {
-      bonus += 0.5;
+      buffMod += 0.5;
     }
 
-    simulation.progression += Math.floor((Math.floor(progressionIncrease) * potency * bonus) / 100);
+    simulation.progression += Math.floor((Math.floor(progressionIncrease) * conditionMod * potency * buffMod) / 100);
 
     if (
       simulation.hasBuff(Buff.FINAL_APPRAISAL) &&

--- a/src/model/actions/quality-action.ts
+++ b/src/model/actions/quality-action.ts
@@ -10,33 +10,34 @@ export abstract class QualityAction extends GeneralAction {
   }
 
   execute(simulation: Simulation, safe = false, skipStackAddition = false): void {
-    let bonus = this.getBaseBonus(simulation);;
+    let buffMod = this.getBaseBonus(simulation);
+    let conditionMod = this.getBaseCondition(simulation);
     let potency = this.getPotency(simulation);
-    let qualityIncrease = this.getBaseQuality(simulation);
+    const qualityIncrease = this.getBaseQuality(simulation);
 
     switch (simulation.state) {
       case StepState.EXCELLENT:
-        qualityIncrease *= 4;
+        conditionMod *= 4;
         break;
       case StepState.POOR:
-        qualityIncrease *= 0.5;
+        conditionMod *= 0.5;
         break;
       case StepState.GOOD:
-        qualityIncrease *= 1.5;
+        conditionMod *= 1.5;
         break;
       default:
         break;
     }
 
     if (simulation.hasBuff(Buff.GREAT_STRIDES)) {
-      bonus += 1;
+      buffMod += 1;
       simulation.removeBuff(Buff.GREAT_STRIDES);
     }
     if (simulation.hasBuff(Buff.INNOVATION)) {
-      bonus += 0.5;
+      buffMod += 0.5;
     }
 
-    simulation.quality += Math.floor((Math.floor(qualityIncrease) * potency * bonus) / 100);
+    simulation.quality += Math.floor((Math.floor(qualityIncrease * conditionMod) * potency * buffMod) / 100);
 
     if (
       simulation.hasBuff(Buff.INNER_QUIET) &&

--- a/src/model/actions/quality-action.ts
+++ b/src/model/actions/quality-action.ts
@@ -12,7 +12,7 @@ export abstract class QualityAction extends GeneralAction {
   execute(simulation: Simulation, safe = false, skipStackAddition = false): void {
     let buffMod = this.getBaseBonus(simulation);
     let conditionMod = this.getBaseCondition(simulation);
-    let potency = this.getPotency(simulation);
+    const potency = this.getPotency(simulation);
     const qualityIncrease = this.getBaseQuality(simulation);
 
     switch (simulation.state) {
@@ -37,7 +37,11 @@ export abstract class QualityAction extends GeneralAction {
       buffMod += 0.5;
     }
 
-    simulation.quality += Math.floor((Math.floor(qualityIncrease * conditionMod) * potency * buffMod) / 100);
+    const efficiency = potency * buffMod / 100
+
+    simulation.quality += Math.floor(
+      Math.floor(qualityIncrease * conditionMod) * efficiency
+    );
 
     if (
       simulation.hasBuff(Buff.INNER_QUIET) &&

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -6,6 +6,7 @@ import { NameOfTheElements } from '../src/model/actions/buff/name-of-the-element
 import { BrandOfTheElements } from '../src/model/actions/progression/brand-of-the-elements';
 import { CarefulSynthesis } from '../src/model/actions/progression/careful-synthesis';
 import { Groundwork } from '../src/model/actions/progression/groundwork';
+import { RapidSynthesis } from '../src/model/actions/progression/rapid-synthesis';
 import { FinalAppraisal } from '../src/model/actions/buff/final-appraisal';
 import { InnerQuiet } from '../src/model/actions/buff/inner-quiet';
 import { WasteNot } from '../src/model/actions/buff/waste-not';
@@ -165,6 +166,21 @@ describe('Craft simulator tests', () => {
     );
     const result2 = simulation2.run(true);
     expect(result2.simulation.durability).toBe(70 - 3);
+  });
+
+  it('Should use floor correctly with MALLEABLE step state', () => {
+    const simulation = new Simulation(
+      generateStarRecipe(513, 12046, 81447, 2620, 2540, true),
+      [new Veneration(), new RapidSynthesis()],
+      generateStats(80, 2763, 2800, 554),
+      [],
+      {
+        1: StepState.MALLEABLE
+      }
+    );
+
+    const result = simulation.run(true);
+    expect(result.simulation.progression).toBe(5298);
   });
 
   it('Should floor control bonuses properly', () => {


### PR DESCRIPTION
Silly title. TL;DR Progress applies condition *after* flooring rather than before. Test as per #36, and validated against some sample data I asked for in Discord. I also took the chance to restructure the way we write the formula in code to be easier to read/maintain, and cleaned up the Delicate Synthesis code a bit.