### PR TITLE
Correctly simulate random crafting conditions

### DIFF
--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -371,4 +371,40 @@ describe('Craft simulator tests', () => {
       StepState.PRIMED
     ]);
   });
+
+  it('Should apply conditions with the proper rates for expert 2 recipes', () => {
+    const simulation = new Simulation(
+      generateRecipe(480, 6178, 36208, 2480, 2195, 483),
+      [],
+      generateStats(80, 2745, 2885, 626),
+      [],
+      [],
+      []
+    );
+
+    simulation.recipe.expert = true;
+
+    const rates: { [state in StepState]?: number } = {
+      [StepState.NORMAL]: 0,
+      [StepState.GOOD]: 0,
+      [StepState.STURDY]: 0,
+      [StepState.PLIANT]: 0,
+      [StepState.MALLEABLE]: 0,
+      [StepState.PRIMED]: 0
+    };
+
+    const numSamples = 100000;
+
+    for (let i = 0; i < numSamples; i++) {
+      simulation.tickState();
+      rates[simulation.state]! += 1;
+    }
+
+    expect(rates[StepState.NORMAL]! / numSamples).toBeCloseTo(0.37, 1);
+    expect(rates[StepState.GOOD]! / numSamples).toBeCloseTo(0.12, 1);
+    expect(rates[StepState.STURDY]! / numSamples).toBeCloseTo(0.15, 1);
+    expect(rates[StepState.PLIANT]! / numSamples).toBeCloseTo(0.12, 1);
+    expect(rates[StepState.MALLEABLE]! / numSamples).toBeCloseTo(0.12, 1);
+    expect(rates[StepState.PRIMED]! / numSamples).toBeCloseTo(0.12, 1);
+  });
 });


### PR DESCRIPTION
This change fixes the math logic for ticking the next crafting state.

For a 5.41 expert recipe, the previous implementation mistakenly assigned conditional probabilities to the states:


```
P(Good) = 0.12
P(Pliant | Good) = 0.12
P(Malleable | not Pliant, not Good) = 0.12
P(Primed | not Malleable, not Pliant, not Good) = 0.12
P(Sturdy | not Primed, not Malleable, not Pliant, not Good) = 0.15
P(Normal | not Sturdy, not Primed, not Malleable, not Pliant, not Good)) = 1
```

This leads to a noticeable difference in the marginal probabilities of each individual state (as verified by the test also added in this PR):
```
P(Good) = 0.12
P(Pliant) = 0.1056
P(Malleable) = 0.092928
P(Primed) = 0.08177664
P(Sturdy) = 0.089954304
P(Normal) = 0.509741056
```

Long story short, we should only roll once to randomize the next crafting state and not N times (where N is the number of states).

## Addendum

If you really want to check the math for the discrepancy in probabilities, here you go.
```
P(Good) = 0.12
P(Pliant) = P(Pliant | not Good) * P(not Good)
          = 0.12 * (1 - 0.12)
          = 0.1056
P(Malleable) = P(Malleable | not Pliant, not Good) * P(not Pliant, not Good)
             = P(Malleable | not Pliant, not Good) * P(not Pliant | not Good) * P(not Good)
             = 0.12 * (1 - 0.12) * (1 - 0.12)
             = 0.092928
P(Primed) = P(Primed | not Malleable, not Pliant, not Good) * P(not Malleable, not Pliant, not Good)
          = P(Primed | not Malleable, not Pliant, not Good) * P(not Malleable | not Pliant, not Good)] * (not Pliant, not Good)
          = 0.12 * (1 - 0.12) * ((1 - 0.12) * (1 - 0.12))
          = 0.08177664
P(Sturdy) = P(Sturdy | not Primed, not Malleable, not Pliant, not Good) * P(not Primed, not Malleable, not Pliant, not Good)
          = P(Sturdy | not Primed, not Malleable, not Pliant, not Good) * P(not Primed | not Malleable, not Pliant, not Good) * P(not Malleable, not Pliant, not Good)
          = 0.15 * (1 - 0.12) * ((1 - 0.12) * ((1 - 0.12) * (1 - 0.12)))
          = 0.089954304
P(Normal) = P(Normal | not Sturdy, not Primed, not Malleable, not Pliant, not Good) * P(not Sturdy, not Primed, not Malleable, not Pliant, not Good)
          = P(Normal | not Sturdy, not Primed, not Malleable, not Pliant, not Good) * P(not Sturdy | not Primed, not Malleable, not Pliant, not Good) * P(not Primed, not Malleable, not Pliant, not Good)
          = 1 * (1 - 0.15) * ((1 - 0.12) * ((1 - 0.12) * ((1 - 0.12) * (1 - 0.12))))
          = 0.509741056
```