### PR TITLE
Properly floor the added negative cost with Pliant

### DIFF
--- a/src/model/actions/crafting-action.ts
+++ b/src/model/actions/crafting-action.ts
@@ -144,7 +144,7 @@ export abstract class CraftingAction {
   public getCPCost(simulationState: Simulation, linear = false): number {
     const baseCost = this.getBaseCPCost(simulationState);
     if (simulationState.state === StepState.PLIANT) {
-      return Math.floor(baseCost / 2);
+      return Math.ceil(baseCost / 2);
     }
     return baseCost;
   }

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -142,6 +142,20 @@ describe('Craft simulator tests', () => {
     expect(result.simulation.availableCP).toBe(541 - 6 - Math.floor(56 / 2));
   });
 
+  it('Should reduce CP cost with PLIANT step state', () => {
+    const simulation = new Simulation(
+      generateStarRecipe(480, 4943, 32328, 2480, 2195, true),
+      [new PrudentTouch()],
+      generateStats(80, 2800, 2500, 541),
+      [],
+      {
+        0: StepState.PLIANT
+      }
+    );
+    const result = simulation.run(true);
+    expect(result.simulation.availableCP).toBe(541 - 13);
+  });
+
   it('Should reduce Durability cost with STURDY step state', () => {
     const simulation = new Simulation(
       generateStarRecipe(480, 4943, 32328, 2480, 2195, true),


### PR DESCRIPTION
The game actually adds a negative cost, rather than subtracting a positive, so like Sturdy, the Pliant modifier also needs to ceiling rather than floor.