### PR TITLE
Fix incorrect Excellent state probability

### DIFF
--- a/src/simulation/simulation.ts
+++ b/src/simulation/simulation.ts
@@ -439,7 +439,7 @@ export class Simulation {
             rate = this.recipe.expert ? 0.12 : goodChance;
             break;
           case StepState.EXCELLENT:
-            rate = this.recipe.expert ? 0 : 0.4;
+            rate = this.recipe.expert ? 0 : 0.04;
             break;
           case StepState.POOR:
             rate = 0;


### PR DESCRIPTION
Excellent is 4%, not 40%. Resolves #49.