### PR TITLE
Add conditions for RemoveFinalAppraisal action

### DIFF
--- a/src/model/actions/other/remove-final-appraisal.ts
+++ b/src/model/actions/other/remove-final-appraisal.ts
@@ -14,7 +14,7 @@ export class RemoveFinalAppraisal extends CraftingAction {
   }
 
   _canBeUsed(simulationState: Simulation): boolean {
-    return true;
+    return simulationState.hasBuff(Buff.FINAL_APPRAISAL);
   }
 
   execute(simulation: Simulation): void {


### PR DESCRIPTION
We should only allow the RemoveFinalAppraisal action if there is a currently active FinalAppraisal buff.