### PR TITLE
fix rounding error for progress actions

### DIFF
--- a/src/model/actions/other/delicate-synthesis.ts
+++ b/src/model/actions/other/delicate-synthesis.ts
@@ -16,7 +16,7 @@ export class DelicateSynthesis extends GeneralAction {
 
   execute(simulation: Simulation): void {
     // Progress
-    const progressionIncrease = this.getBaseProgression(simulation);
+    const progressionIncrease = Math.floor(this.getBaseProgression(simulation));
     const progressPotency = this.getPotency(simulation);
     let progressBuffMod = this.getBaseBonus(simulation);
     let progressConditionMod = this.getBaseCondition(simulation);
@@ -37,11 +37,9 @@ export class DelicateSynthesis extends GeneralAction {
       progressBuffMod += 0.5;
     }
 
-    const progressEfficiency = (progressPotency * progressBuffMod) / 100;
+    const progressEfficiency = progressPotency * progressBuffMod;
 
-    simulation.progression += Math.floor(
-      Math.floor(progressionIncrease) * progressConditionMod * progressEfficiency
-    );
+    simulation.progression += Math.floor((progressionIncrease * progressConditionMod * progressEfficiency) / 100);
 
     if (
       simulation.hasBuff(Buff.FINAL_APPRAISAL) &&

--- a/src/model/actions/progress-action.ts
+++ b/src/model/actions/progress-action.ts
@@ -13,7 +13,7 @@ export abstract class ProgressAction extends GeneralAction {
     let buffMod = this.getBaseBonus(simulation);
     let conditionMod = this.getBaseCondition(simulation);
     const potency = this.getPotency(simulation);
-    const progressionIncrease = this.getBaseProgression(simulation);
+    const progressionIncrease = Math.floor(this.getBaseProgression(simulation));
 
     switch (simulation.state) {
       case StepState.MALLEABLE:
@@ -31,11 +31,9 @@ export abstract class ProgressAction extends GeneralAction {
       buffMod += 0.5;
     }
 
-    const efficiency = Math.fround((potency * buffMod) / 100);
+    const efficiency = potency * buffMod;
 
-    simulation.progression += Math.floor(
-      Math.floor(progressionIncrease) * conditionMod * efficiency
-    );
+    simulation.progression += Math.floor((progressionIncrease * conditionMod * efficiency) / 100);
 
     if (
       simulation.hasBuff(Buff.FINAL_APPRAISAL) &&

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -478,4 +478,18 @@ describe('Craft simulator tests', () => {
     simulation.run();
     expect(simulation.quality).toBeGreaterThan(0);
   });
+  
+  it('Progress flooring', () => {
+    const simulation = new Simulation(
+      generateRecipe(535, 3000, 6700, 125, 109),
+      [
+        new CarefulSynthesis(),
+      ],
+      generateStats(90, 2606, 2457, 507)
+    );
+
+    simulation.run(true);
+
+    expect(simulation.progression).toBe(378);
+  });
 });


### PR DESCRIPTION
**Issue:** 
> **Wrong rounding of progress added by progress actions**
> The calculation for progress actions does not always round correctly when it should resulting in being off by 1.

**Steps to Reproduce:**
> Setup: (Full ilvl 500 scrip gear)
> Craftsmanship: 2606 Control: 2457
> CP: 507 Level: 90
> Recipe: Rarefied Happiness Juice
> 
> Rotation: ["carefulSynthesis"]
> 
> Rotation Ingame Progress: 378 
> Rotation Teamcraft Progress: 377

**Expected Behaviour:**
> The Progress in game and in Teamcraft should be the same.
**Teamcraft Version - Browser / Desktop Client**
> 9.6.3  in Chrome and Standalone client

**Test case:**
```ts
it('Progress flooring', () => {
  const simulation = new Simulation(
    generateRecipe(535, 3000, 6700, 125, 109),
    [
      new CarefulSynthesis(),
    ],
    generateStats(90, 2606, 2457, 507)
  );

  simulation.run(true);

  expect(simulation.progression).toBe(378);
});
```
**Solution:**
In teamcraft-sim/src/model/actions/progress-action.ts change:
```diff
--- a/src/model/actions/progress-action.ts
+++ b/src/model/actions/progress-action.ts
@@ -15,3 +15,3 @@
     const potency = this.getPotency(simulation);
-    const progressionIncrease = this.getBaseProgression(simulation);
+    const progressionIncrease = Math.floor(this.getBaseProgression(simulation));
 
@@ -33,7 +33,5 @@
 
-    const efficiency = Math.fround((potency * buffMod) / 100);
+    const efficiency = potency * buffMod;
 
-    simulation.progression += Math.floor(
-      Math.floor(progressionIncrease) * conditionMod * efficiency
-    );
+    simulation.progression += Math.floor((progressionIncrease * conditionMod * efficiency) / 100);
 
```
**Screenshots:**
1: Ingame result
2: Teamcraft result
3: Patch dif
![1_Ingame_Result](https://user-images.githubusercontent.com/4653051/167644269-bf4c98d6-81d5-4507-a12b-e474de2f02aa.png)
![2_Teamcraft_Result](https://user-images.githubusercontent.com/4653051/167644277-5a7e6a95-b420-4664-aa51-cfc084611e4a.png)
![3_Patch](https://user-images.githubusercontent.com/4653051/167644278-58cc04fd-150b-48bc-89db-7ded490279b7.png)
f