### PR TITLE
Fix precision issue with buffMod calculation of Quality actions

### DIFF
--- a/src/model/actions/crafting-action.ts
+++ b/src/model/actions/crafting-action.ts
@@ -177,17 +177,17 @@ export abstract class CraftingAction {
     const stats = simulation.crafterStats;
     const baseValue = (stats.craftsmanship * 10) / simulation.recipe.progressDivider + 2;
     if (Tables.LEVEL_TABLE[stats.level] <= simulation.recipe.rlvl) {
-      return baseValue * (simulation.recipe.progressModifier || 100) * Math.fround(0.01);
+      return Math.floor(baseValue * (simulation.recipe.progressModifier || 100) * Math.fround(0.01));
     }
-    return baseValue;
+    return Math.floor(baseValue);
   }
 
   public getBaseQuality(simulation: Simulation): number {
     const stats = simulation.crafterStats;
     const baseValue = (stats.getControl(simulation) * 10) / simulation.recipe.qualityDivider + 35;
     if (Tables.LEVEL_TABLE[stats.level] <= simulation.recipe.rlvl) {
-      return baseValue * (simulation.recipe.qualityModifier || 100) * Math.fround(0.01);
+      return Math.floor(baseValue * (simulation.recipe.qualityModifier || 100) * Math.fround(0.01));
     }
-    return baseValue;
+    return Math.floor(baseValue);
   }
 }

--- a/src/model/actions/other/delicate-synthesis.ts
+++ b/src/model/actions/other/delicate-synthesis.ts
@@ -16,7 +16,7 @@ export class DelicateSynthesis extends GeneralAction {
 
   execute(simulation: Simulation): void {
     // Progress
-    const progressionIncrease = Math.floor(this.getBaseProgression(simulation));
+    const progressionIncrease = this.getBaseProgression(simulation);
     const progressPotency = this.getPotency(simulation);
     let progressBuffMod = this.getBaseBonus(simulation);
     let progressConditionMod = this.getBaseCondition(simulation);

--- a/src/model/actions/progress-action.ts
+++ b/src/model/actions/progress-action.ts
@@ -13,7 +13,7 @@ export abstract class ProgressAction extends GeneralAction {
     let buffMod = this.getBaseBonus(simulation);
     let conditionMod = this.getBaseCondition(simulation);
     const potency = this.getPotency(simulation);
-    const progressionIncrease = Math.floor(this.getBaseProgression(simulation));
+    const progressionIncrease = this.getBaseProgression(simulation);
 
     switch (simulation.state) {
       case StepState.MALLEABLE:

--- a/src/model/actions/quality-action.ts
+++ b/src/model/actions/quality-action.ts
@@ -13,7 +13,7 @@ export abstract class QualityAction extends GeneralAction {
     let buffMod = this.getBaseBonus(simulation);
     let conditionMod = this.getBaseCondition(simulation);
     const potency = this.getPotency(simulation);
-    const qualityIncrease = Math.floor(this.getBaseQuality(simulation));
+    const qualityIncrease = this.getBaseQuality(simulation);
 
     switch (simulation.state) {
       case StepState.EXCELLENT:

--- a/src/model/actions/quality-action.ts
+++ b/src/model/actions/quality-action.ts
@@ -13,7 +13,7 @@ export abstract class QualityAction extends GeneralAction {
     let buffMod = this.getBaseBonus(simulation);
     let conditionMod = this.getBaseCondition(simulation);
     const potency = this.getPotency(simulation);
-    const qualityIncrease = this.getBaseQuality(simulation);
+    const qualityIncrease = Math.floor(this.getBaseQuality(simulation));
 
     switch (simulation.state) {
       case StepState.EXCELLENT:
@@ -29,7 +29,7 @@ export abstract class QualityAction extends GeneralAction {
         break;
     }
 
-    buffMod += (simulation.getBuff(Buff.INNER_QUIET)?.stacks || 0) / 10;
+    buffMod = Math.fround(buffMod + (simulation.getBuff(Buff.INNER_QUIET)?.stacks || 0) / 10);
 
     let buffMult = 1;
     if (simulation.hasBuff(Buff.GREAT_STRIDES)) {
@@ -40,11 +40,11 @@ export abstract class QualityAction extends GeneralAction {
       buffMult += 0.5;
     }
 
-    buffMod *= buffMult;
+    buffMod = buffMod * buffMult;
 
-    const efficiency = Math.fround((potency * buffMod) / 100);
+    const efficiency = potency * buffMod;
 
-    simulation.quality += Math.floor(Math.floor(qualityIncrease) * conditionMod * efficiency);
+    simulation.quality += Math.floor((qualityIncrease * conditionMod * efficiency) / 100);
 
     if (!skipStackAddition) {
       simulation.addInnerQuietStacks(1);

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -492,4 +492,21 @@ describe('Craft simulator tests', () => {
 
     expect(simulation.progression).toBe(378);
   });
+  
+  it('Quality Buff flooring', () => {
+    const simulation = new Simulation(
+      generateRecipe(285, 980, 3420, 88, 68),
+      [
+        new Innovation(),
+        new PrudentTouch(),
+        new PrudentTouch(),
+        new PrudentTouch(),
+      ],
+      generateStats(66, 813, 683, 283)
+    );
+	
+	simulation.run(true);
+	
+	expect(simulation.quality).toBe(667);
+  });
 });


### PR DESCRIPTION
**Issue:**
> **Precision issue with Quality actions buffMod**
> The calculation of the added quality for quality actions is not correctly constrained to be 32bit which in some cases it resulted in being off by 1.

**Steps to Reproduce:**
> Setup:
> Craftsmanship: 813 Control: 683
> CP: 283 Level: 68
> Recipe: Rarefied Durium Rod
> 
> Rotation: ["innovation", "prudentTouch", "prudentTouch", "prudentTouch"]
> 
> Rotation Ingame Quality: 667
> Rotation Teamcraft Quality: 666

**Expected Behaviour:**
> The Quality in game and in Teamcraft should be the same.
**Teamcraft Version - Browser / Desktop Client**
> 9.6.8  in Chrome and Standalone client

**Screenshots:**
1: Teamcraft result
2: ingame step 1
3: ingame step 2
4: ingame step 3
5: ingame step 4 / result

![image](https://user-images.githubusercontent.com/4653051/169709658-0a4540f9-3c34-4876-9601-a177bcb9ebbc.png)
![image](https://user-images.githubusercontent.com/4653051/169709695-ea9e866f-a628-4610-962c-9a8944d480a2.png)
![image](https://user-images.githubusercontent.com/4653051/169709661-0adbd922-feb4-48ae-8fdb-6bb4f82fe5dc.png)
![image](https://user-images.githubusercontent.com/4653051/169709702-65584371-c631-48ea-b06e-bced727c2d65.png)
![image](https://user-images.githubusercontent.com/4653051/169709705-9cb4a8ab-8369-4fee-bb48-76bb3fc9a81a.png)
