### PR TITLE
Respect Collectibility Tiers in Min Stats

### DIFF
--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -613,4 +613,29 @@ describe('Craft simulator tests', () => {
 
     expect(simulation2.getBuff(Buff.HEART_AND_SOUL)).toBeUndefined();
   });
+
+  it('Should correctly identify Collectibility tiers for min stats', () => {
+    const simulation = new Simulation(
+      generateRecipe(560, 3500, 7200, 130, 115, 15, { progressModifier: 90, qualityModifier: 80 }),
+      [
+        new MuscleMemory(),
+        new WasteNotII(),
+        new Groundwork(),
+        new DelicateSynthesis(),
+        new Innovation(),
+        new PreparatoryTouch(),
+        new PreparatoryTouch(),
+        new PreparatoryTouch(),
+        new PreparatoryTouch(),
+        new ByregotsBlessing(),
+        new CarefulSynthesis(),
+      ],
+      generateStats(90, 4021, 3600, 601)
+    );
+
+    const stats = simulation.getMinStats(true, { low: 396, mid: 540, high: 684 });
+    expect(stats.found).toBe(true);
+    expect(stats.craftsmanship).toBe(3875);
+    expect(stats.control).toBe(2962);
+  });
 });


### PR DESCRIPTION
Min stats calculations rely on HQ percentage. This doesn't really work for collectibility as it's a factor of 10 rather than 100, and we don't really need the same percentage as we do the tiers. Default collect bool is false so it's backwards compatible with other users, tiers can be provided by the user so we don't need to pull it into any of our structures.

The test targets the mid-tier, 540 collect, using this rotation. We check tiers top down so if they don't hit any, we can fallback to whatever collectibility they *did* get. If tiers aren't defined, we use the normal behaviour too.

![image](https://user-images.githubusercontent.com/28627120/217724449-a61ba809-ec69-4386-ada9-db01fb4513e2.png)
