### PR TITLE
Bisection Algorithm for Min Stats Calculations

### DIFF
--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -614,6 +614,32 @@ describe('Craft simulator tests', () => {
     expect(simulation2.getBuff(Buff.HEART_AND_SOUL)).toBeUndefined();
   });
 
+  it('Should calculate min stats', () => {
+    const simulation = new Simulation(
+      generateRecipe(525, 1300, 6200, 123, 107, 15, { durability: 40 }),
+      [
+        new Reflect(),
+        new Groundwork(),
+        new MastersMend(),
+        new Manipulation(),
+        new WasteNot(),
+        new PreparatoryTouch(),
+        new PreparatoryTouch(),
+        new PreparatoryTouch(),
+        new PreparatoryTouch(),
+        new ByregotsBlessing(),
+        new BasicSynthesis(),
+      ],
+      generateStats(90, 4021, 3600, 500)
+    );
+
+    const stats = simulation.getMinStats();
+    expect(stats.found).toBe(true);
+    expect(stats.craftsmanship).toBe(3309);
+    expect(stats.control).toBe(3125);
+    expect(stats.cp).toBe(448);
+  });
+
   it('Should correctly identify Collectibility tiers for min stats', () => {
     const simulation = new Simulation(
       generateRecipe(560, 3500, 7200, 130, 115, 15, { progressModifier: 90, qualityModifier: 80 }),

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -663,5 +663,6 @@ describe('Craft simulator tests', () => {
     expect(stats.found).toBe(true);
     expect(stats.craftsmanship).toBe(3875);
     expect(stats.control).toBe(2962);
+    expect(stats.cp).toBe(363);
   });
 });


### PR DESCRIPTION
With stats getting close to 4500, we're soon going to run into limits with the iteration algorithm as the total stats will be larger than 10,000. This also gets progressively slower as stats get higher. I thought about the approach git's bisect method uses and had a go with it here: basic binary search with a guard on both outcomes, using the stat as input. There are a few alternatives but I felt this was the simplest to implement, and it's about 20x faster than the current iterator. In terms of loops, the test added in this PR runs 6700 iterations, and the bisector runs 34 iterations.

Not really sure this is a great implementation, assigned to a const felt right at the time until I needed to switch stats and control required special handling. Happy to answer any questions or if you've got better ideas on any of it.

I recommend reading the diff in split diff mode instead of unified, it helps a lot.