### PR TITLE
Threshold Fixup

### DIFF
--- a/src/simulation/simulation.ts
+++ b/src/simulation/simulation.ts
@@ -198,6 +198,7 @@ export class Simulation {
       this.reset();
       result = this.run(true);
 
+      // CP needs to know we didn't gimp quality, so check both values
       if (result.success && result.hqPercent >= originalHqPercent) {
         // Due to flooring, if the 2 numbers are adjacent, test will be the same as the lower
         if (test === start) {
@@ -249,6 +250,7 @@ export class Simulation {
           ? result.simulation.quality
           : result.hqPercent;
 
+      // Switch between the 2 control targets
       if (outcome < comparator) {
         if (test === end - 1) {
           this.crafterStats._control = end;

--- a/src/simulation/simulation.ts
+++ b/src/simulation/simulation.ts
@@ -144,6 +144,11 @@ export class Simulation {
     }
   }
 
+  /**
+   *
+   * @param thresholds an array of quality thresholds, Collectibility ratings must be scaled before input
+   * @returns a boolean for successful calculation, and the minimum value for each stat
+   */
   public getMinStats(thresholds: Array<number> = []): {
     control: number;
     craftsmanship: number;

--- a/src/simulation/simulation.ts
+++ b/src/simulation/simulation.ts
@@ -265,8 +265,16 @@ export class Simulation {
       }
     };
 
-    res.craftsmanship = bisect('cms', 1, originalStats.craftsmanship);
-    res.control = bisectControl(1, originalStats._control);
+    // Narrow the window when possible, or return the min if we're too low
+    const cmsBase = this.recipe.craftsmanshipReq ?? 1;
+    res.craftsmanship =
+      cmsBase < originalStats.craftsmanship
+        ? bisect('cms', cmsBase, originalStats.craftsmanship)
+        : cmsBase;
+
+    const ctlBase = this.recipe.controlReq ?? 1;
+    res.control =
+      ctlBase < originalStats._control ? bisectControl(ctlBase, originalStats._control) : ctlBase;
 
     // We need to reset control to make sure result.hqPercent is accurate
     this.crafterStats._control = originalStats._control;

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -640,7 +640,7 @@ describe('Craft simulator tests', () => {
     expect(stats.cp).toBe(448);
   });
 
-  it('Should correctly identify Collectibility tiers for min stats', () => {
+  it('Should correctly identify tier thresholds for min stats', () => {
     const simulation = new Simulation(
       generateRecipe(560, 3500, 7200, 130, 115, 15, { progressModifier: 90, qualityModifier: 80 }),
       [
@@ -659,7 +659,7 @@ describe('Craft simulator tests', () => {
       generateStats(90, 4021, 3600, 601)
     );
 
-    const stats = simulation.getMinStats(true, { low: 396, mid: 540, high: 684 });
+    const stats = simulation.getMinStats([3960, 5400, 6840]);
     expect(stats.found).toBe(true);
     expect(stats.craftsmanship).toBe(3875);
     expect(stats.control).toBe(2962);


### PR DESCRIPTION
A few things in this PR, but related:

- update tier definitions to `Array<number>` for multi-purpose use (eg required quality)
- move tier definitions to pure thresholds (collectibles will need to x10 their inputs)
- update stat window calculation to use required minimums as a base when they're defined