### PR TITLE
Handle Splendorous Tools on Good Condition

### DIFF
--- a/src/model/actions/other/delicate-synthesis.ts
+++ b/src/model/actions/other/delicate-synthesis.ts
@@ -69,7 +69,7 @@ export class DelicateSynthesis extends GeneralAction {
         conditionMod *= 0.5;
         break;
       case StepState.GOOD:
-        conditionMod *= 1.5;
+        conditionMod *= simulation.crafterStats.splendorous ? 1.75 : 1.5;
         break;
       default:
         break;

--- a/src/model/actions/quality-action.ts
+++ b/src/model/actions/quality-action.ts
@@ -23,7 +23,7 @@ export abstract class QualityAction extends GeneralAction {
         conditionMod *= 0.5;
         break;
       case StepState.GOOD:
-        conditionMod *= 1.5;
+        conditionMod *= simulation.crafterStats.splendorous ? 1.75 : 1.5;
         break;
       default:
         break;

--- a/src/model/crafter-stats.ts
+++ b/src/model/crafter-stats.ts
@@ -9,6 +9,7 @@ export class CrafterStats {
     public _control: number,
     public cp: number,
     public readonly specialist: boolean,
+    public readonly splendorous: boolean,
     public readonly level: number,
     public readonly levels: CrafterLevels
   ) {}

--- a/src/model/gear-set.ts
+++ b/src/model/gear-set.ts
@@ -5,4 +5,5 @@ export interface GearSet {
   craftsmanship: number;
   cp: number;
   specialist: boolean;
+  splendorous: boolean;
 }

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -65,9 +65,10 @@ export function generateStats(
   level: number,
   craftsmanship: number,
   control = 3000,
-  cp = 539
+  cp = 539,
+  splendorous = false
 ): CrafterStats {
-  return new CrafterStats(14, craftsmanship, control, cp, true, level, [
+  return new CrafterStats(14, craftsmanship, control, cp, true, splendorous, level, [
     level,
     level,
     level,

--- a/test/simulation.spec.ts
+++ b/test/simulation.spec.ts
@@ -665,4 +665,19 @@ describe('Craft simulator tests', () => {
     expect(stats.control).toBe(2962);
     expect(stats.cp).toBe(363);
   });
+
+  it('Should use the enhanced Good modifier with Splendorous tools', () => {
+    const simulation = new Simulation(
+      generateRecipe(1, 9, 80, 50, 30),
+      [new Observe(), new BasicTouch()],
+      generateStats(90, 4041, 3987, 616, true),
+      [],
+      {
+        1: StepState.GOOD,
+      }
+    );
+
+    simulation.run(true);
+    expect(simulation.quality).toBe(2387);
+  });
 });


### PR DESCRIPTION
As it says on the tin. Since Splendorous tools are job-specific I felt it made more sense to be part of the crafter stats rather than the recipe itself. Added the field into the GearSet model as well so the Teamcraft job stats can use it in gearsets.